### PR TITLE
feat: 커뮤니티 페이지 라우팅 및 기본 틀 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import CommunityPage from "./pages/CommunityPage";
+import Community from "./pages/Community";
 
 const queryClient = new QueryClient();
 
@@ -17,6 +19,8 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/community" element={<Community />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,0 +1,21 @@
+// src/pages/Community.tsx
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+const Community = () => {
+  return (
+    <div className="min-h-screen bg-background font-korean p-6 max-w-4xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">커뮤니티 게시판</h1>
+
+      <Card>
+        <CardContent className="p-4">
+          <p className="text-gray-500">백엔드 API 연결 예정. 게시글 목록이 여기에 표시됩니다.</p>
+        </CardContent>
+      </Card>
+
+      <Button variant="default">게시글 작성</Button>
+    </div>
+  );
+};
+
+export default Community;

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -1,0 +1,12 @@
+const CommunityPage = () => {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">커뮤니티 페이지</h1>
+      <p className="text-muted-foreground">
+        백엔드 API 테스트용 게시판이 여기에 들어갈 예정입니다.
+      </p>
+    </div>
+  );
+};
+
+export default CommunityPage;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Heart, Bookmark, LogIn } from "lucide-react";
+import { Link } from "react-router-dom";
 
 type UserType = "job_seeker" | "agent" | "company";
 
@@ -159,6 +160,9 @@ const Index = () => {
             <h1 className="text-2xl font-bold text-primary">
               Job<span className="text-foreground">談</span>
             </h1>
+            <Link to="/community" className="text-sm text-muted-foreground hover:underline">
+  커뮤니티
+</Link>
           </div>
           
           <Button className="flex items-center gap-2">


### PR DESCRIPTION
- SNS 피드에서 커뮤니티로 이동할 수 있는 링크 추가
- /community 라우트에 커뮤니티 게시판 기본 구성 페이지 작성
- 이후 게시판 CRUD 작업 테스트용으로 활용 예정